### PR TITLE
fix (bower) rise angular version dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,1 +1,14 @@
-{"name":"ngHelperBusy","main":["ngHelperBusy.js","ngHelperBusy.css"],"version":"0.3.3","homepage":"https://github.com/ngHelper/ngHelperBusy","authors":["dei79 <dirk.eisenberg@gmail.com>"],"description":"A full screen busy indicator which is controlled by the $busy service and supports","keywords":["angular","angularjs","busy","service","directive"],"license":"MIT","ignore":["**/.*","node_modules","bower_components","test","tests"],"dependencies":{"angular":"~1.2"}}
+{
+  "name": "ngHelperBusy",
+  "main": ["ngHelperBusy.js", "ngHelperBusy.css"],
+  "version": "0.3.3",
+  "homepage": "https://github.com/ngHelper/ngHelperBusy",
+  "authors": ["dei79 <dirk.eisenberg@gmail.com>"],
+  "description": "A full screen busy indicator which is controlled by the $busy service and supports",
+  "keywords": ["angular", "angularjs", "busy", "service", "directive"],
+  "license": "MIT",
+  "ignore": ["**/.*", "node_modules", "bower_components", "test", "tests"],
+  "dependencies": {
+    "angular": "^1.2"
+  }
+}


### PR DESCRIPTION
Impossible to install ngHelperBusy with the last version of AngularJS 1.x

see #1
